### PR TITLE
add helpfile tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 test/*
+doc/tags


### PR DESCRIPTION
When adding this plugin as a submodule and generating helptags, the tags file appears as an untracked file. This fixes it.

Another solution would be to track the tags file.. I'm not sure which is better :shrug: 